### PR TITLE
dishesByCategoryMenu: support multiple orders grouped by cuisine

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest": "tsc --noEmit",
     "update:playwright": "playwright install --with-deps",
     "test:record": "npx playwright codegen --viewport-size=375,812 http://uatemployee.cocaptain.co.in/#/login/x713fo2tx5",
-    "test": "cross-env ENV=qa npx playwright test  --grep @E2E",
+    "test": "cross-env ENV=qa npx playwright test  --grep @RK",
     "test:chrome": "npx playwright test --project=Chrome",
     "test:new": "npx playwright test",
     "test:debug": "npx playwright test --headed --debug",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 require('dotenv').config();
-//export const testDir = './tests';
+export const testDir = './tests';
 export const timeout = 60000;
 export const retries = 0;
 export const workers = process.env.CI ? 1 : 1;

--- a/tests/MultipleOrderWithDifferentDishes.spec.ts
+++ b/tests/MultipleOrderWithDifferentDishes.spec.ts
@@ -3,11 +3,17 @@ import { AdminHelper } from '../utils/adminHelper';
 import { testData } from '../fixture/testData';
 import { launchBrowserAt, createAdminContext, createKotContext, createUserContext } from '../utils/browserHelper';
 
-const menu = 'Chicken Biriyani';
+
+ const dishesByCategory = {
+    "main Course": ['Nattukozhi pepper fry','Mutton boti masala (Gravy)'],
+    "Chinese": ['Tandoori chicken Full'],
+    "starter": ['Chinthamani Chicken'],
+    "Non-Veg": ['Vanjaram Fry']
+  };
 
 // Test Suite
-test.describe('@E2E', () => {
-  test('User Placing an order with SameDish with multiple quantity', async () => {
+test.describe('@RK', () => {
+  test('User Placing an order with different dishes', async () => {
     test.setTimeout(120_000);
     
     // 1. Launch the browser in headed mode with a specified window size
@@ -37,27 +43,27 @@ test.describe('@E2E', () => {
     await AdminHelper.checkUserApproved(adminPage, testData.APPROVE_LIST_URL, subscriptionValue);
 
     // 8. User places an order
-    await AdminHelper.searchAndPlaceForMultipleOrder(userPage, menu, 3);
-    await AdminHelper.checkOrderStatus(userPage, menu, 'Placed');
+    await AdminHelper.searchAndAddDishesByMenuCategory(userPage, dishesByCategory);
+  await AdminHelper.checkOrderStatusForMultipleDishes(userPage,  dishesByCategory, 'Placed');
 
     // 9. KOT logs in to manage orders
     const kotPage = await kotContext.newPage();
     await AdminHelper.login(kotPage, testData.KOT_URL, testData.ORDER_LIST_URL, testData.KOT_CREDENTIALS, 'KOT');
 
     // 10. KOT prepares and dispatches the order
-    await AdminHelper.prepareAndDispatchForMultipleOrder(kotPage, menu, 'Starter 3');
+    await AdminHelper.updateOrderStatusForDifferentDishes(kotPage, dishesByCategory);
     // await AdminHelper.prepareAndDispatchOrder(kotPage, menu, 'Dispatched');
 
     // 11. User checks if the order status has been updated
-    await AdminHelper.checkOrderStatus(userPage, menu, 'Dispatched');
+    await AdminHelper.checkOrderStatusforDifferentDishes(userPage,dishesByCategory, 'Dispatched');
 
     // 12. Server logs in and completes the order
     const serverPage = await serverContext.newPage();
     await AdminHelper.login(serverPage, testData.SERVER_URL, testData.SERVER_LIST_URL, testData.SERVER_CREDENTIALS, 'Server');
-    await AdminHelper.moveMultipleOrderStatus(serverPage);
+    await AdminHelper.moveOrderStatusforCategoryMenu(serverPage, dishesByCategory, 'Done');
 
     // 13. Final user check: confirm order is delivered
-    await AdminHelper.checkOrderStatus(userPage, menu, 'Delivered');
+    await AdminHelper.checkOrderStatusforDifferentDishes(userPage,dishesByCategory, 'Delivered');
 
     // 14. User switches to the order list page
     await AdminHelper.switchToOrderListPage(userPage);


### PR DESCRIPTION
### Summary
This pull request introduces enhancements to the `dishesByCategoryMenu` feature, enabling support for handling multiple orders categorized by cuisine.


### Changes Included
- Added basic validation for cuisine-based order grouping
- Handled multiple order selection per cuisine category

### Motivation
To improve user experience by allowing customers to place multiple dish orders efficiently, sorted by their respective cuisines.